### PR TITLE
Add theme toggle with shadcn button

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,9 +28,19 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(() => {
+              const t = localStorage.getItem('theme');
+              if (t === 'dark' || (!t && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+                document.documentElement.classList.add('dark');
+              }
+            })();`,
+          }}
+        />
         <Header />
         {children}
-        <Footer /> 
+        <Footer />
       </body>
     </html>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { usePathname } from 'next/navigation';
 import { Menu, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import ThemeToggle from './ThemeToggle';
 import Link from 'next/link';
 
 const menuItems = [
@@ -58,18 +59,21 @@ export default function Header() {
           </div>
         </nav>
 
-        {/* Hamburger icon (mobile) */}
-        {!menuOpen && (
-          <Button
-            variant="ghost"
-            size="icon"
-            className="md:hidden text-foreground p-3 ml-auto border border-gray-300 rounded-full bg-white/70 backdrop-blur"
-            onClick={() => setMenuOpen(true)}
-            aria-label="Open menu"
-          >
-            <Menu size={32} />
-          </Button>
-        )}
+        <div className="flex items-center gap-2 ml-auto">
+          <ThemeToggle />
+          {/* Hamburger icon (mobile) */}
+          {!menuOpen && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="md:hidden text-foreground p-3 border border-gray-300 rounded-full bg-white/70 backdrop-blur"
+              onClick={() => setMenuOpen(true)}
+              aria-label="Open menu"
+            >
+              <Menu size={32} />
+            </Button>
+          )}
+        </div>
       </header>
 
       {/* Fullscreen mobile nav */}
@@ -93,14 +97,15 @@ export default function Header() {
               key={item.label}
               href={item.href}
               onClick={() => setMenuOpen(false)}
-              className={`hover:underline transition-colors ${pathname === item.href ? 'text-teal-600 font-semibold' : ''
-                }`}
+              className={`hover:underline transition-colors ${pathname === item.href ? 'text-teal-600 font-semibold' : ''}`}
               target={item.href.startsWith('http') ? '_blank' : undefined}
               rel={item.href.startsWith('http') ? 'noopener noreferrer' : undefined}
             >
               {item.label}
             </Link>
           ))}
+
+          <ThemeToggle />
         </div>
       )}
     </>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Sun, Moon } from 'lucide-react'
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<'light' | 'dark'>('light')
+
+  // Initialize theme on mount
+  useEffect(() => {
+    const stored = typeof window !== 'undefined' ? localStorage.getItem('theme') : null
+    if (stored === 'light' || stored === 'dark') {
+      setTheme(stored)
+      applyTheme(stored)
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setTheme('dark')
+      applyTheme('dark')
+    }
+  }, [])
+
+  const applyTheme = (mode: 'light' | 'dark') => {
+    if (mode === 'dark') {
+      document.documentElement.classList.add('dark')
+    } else {
+      document.documentElement.classList.remove('dark')
+    }
+  }
+
+  const toggleTheme = () => {
+    const nextTheme = theme === 'light' ? 'dark' : 'light'
+    setTheme(nextTheme)
+    applyTheme(nextTheme)
+    localStorage.setItem('theme', nextTheme)
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleTheme}
+      aria-label="Toggle theme"
+    >
+      {theme === 'dark' ? <Sun size={20} /> : <Moon size={20} />}
+    </Button>
+  )
+}


### PR DESCRIPTION
## Summary
- implement a `ThemeToggle` component using shadcn `Button`
- place the theme toggle in the header and mobile nav
- set initial theme on page load via script

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a97146818832b8be297f32f23ef22