### PR TITLE
Add Google Analytics setup

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import Script from "next/script";
 import "./globals.css";
 
 // Font setup
@@ -38,6 +39,20 @@ export default function RootLayout({
             })();`,
           }}
         />
+        {/* Google Analytics */}
+        <Script
+          src="https://www.googletagmanager.com/gtag/js?id=G-R858YCWC8P"
+          strategy="afterInteractive"
+        />
+        <Script id="ga-init" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'G-R858YCWC8P');
+          `}
+        </Script>
         <Header />
         {children}
         <Footer />


### PR DESCRIPTION
## Summary
- include Script in layout
- embed gtag loader and initialization

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ba860f318832bbeb2409a1f9459e9