### PR TITLE
Add SEO sitemap generation

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  siteUrl: 'https://worksofabhiram.com',
+  generateRobotsTxt: true,
+  generateIndexSitemap: false,
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postbuild": "next-sitemap"
   },
   "dependencies": {
     "@fortawesome/free-brands-svg-icons": "^6.7.2",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import Head from 'next/head';
 import Socials from '@/components/socials';
 import ProfileHeader from '@/components/ProfileHeader';
 import ProfileIntro from '@/components/ProfileIntro';
@@ -9,8 +10,31 @@ import { works } from '@/data/workData';
 
 export default function Home() {
   return (
-    <section className="min-h-[90vh] flex items-center justify-center px-4 py-10 md:pt-20">
-      <div className="w-full max-w-5xl flex flex-col gap-10 text-center md:text-left">
+    <>
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'Person',
+              name: 'Abhiram Shaji',
+              url: 'https://worksofabhiram.com',
+              sameAs: [
+                'https://www.linkedin.com/in/abhiram-kace/',
+                'https://github.com/abhiram-shaji',
+              ],
+              jobTitle: 'Full Stack Developer',
+              worksFor: {
+                '@type': 'Organization',
+                name: 'Freelance',
+              },
+            }),
+          }}
+        />
+      </Head>
+      <section className="min-h-[90vh] flex items-center justify-center px-4 py-10 md:pt-20">
+        <div className="w-full max-w-5xl flex flex-col gap-10 text-center md:text-left">
         {/* Header */}
         <ProfileHeader />
         <ProfileIntro />
@@ -30,5 +54,6 @@ export default function Home() {
         </div>
       </div>
     </section>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- set up next-sitemap configuration
- generate robots.txt and sitemap after build
- add structured data markup for home page

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684baaa85ce0832b90a8e9ec8fb5ef87